### PR TITLE
improve availability check after deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,4 +47,7 @@ jobs:
           credentials: ${{ secrets.GCP_SERVICE_CREDENTIALS }}
 
       - name: Test
-        run: curl "${{ steps.deploy.outputs.url }}"
+        run: |
+          response=$(curl "${{ steps.deploy.outputs.url }}")
+          echo $response
+          if [[ "$response" == *"Service Unavailable"* ]]; then exit 1; else echo "App is up and running"; fi


### PR DESCRIPTION
Problem:
- If server is up, but not available, the `curl` command will still pass without error, and will only output that the service is unavailable
- Thus the pipeline passes, which should not be (because server is unavailable)

Changes:
- We want to check the curl answer
- If the answer is that the server is unavailable, then the pipeline should fail. This is achieved with an `exit 1` statement
- If the answer is that the server is available, then the pipeline should pass. (Just outputs that the server is up and running).

Output on available response:
```
Run response=$(curl "***")
sponse=$(curl "***")
  echo $response
  if [[ "$response" == *"Service Unavailable"* ]]; then exit 1; else echo "App is up and running"; fi
  shell: /usr/bin/bash -e ***0***
  env:
    CLOUDSDK_METRICS_ENVIRONMENT: github-actions-deploy-appengine
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:04 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:06 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:07 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:08 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:09 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:10 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:11 --:--:--     0
100    27  100    27    0     0      2      0  0:00:13  0:00:11  0:00:02     6
The application is running.
App is up and running
```

Output on unavailable response:
```
Run response=$(curl "***")
  response=$(curl "***")
  echo $response
  if [[ "$response" == *"Service Unavailable"* ]]; then exit 1; else echo "App is up and running"; fi
  shell: /usr/bin/bash -e ***0***
  env:
    CLOUDSDK_METRICS_ENVIRONMENT: github-actions-deploy-appengine
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:04 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:06 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:07 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:08 --:--:--     0
100    19  100    19    0     0      2      0  0:00:09  0:00:08  0:00:01     4
100    19  100    19    0     0      2      0  0:00:09  0:00:08  0:00:01     5
Service Unavailable
Error: Process completed with exit code 1.
```